### PR TITLE
Add `resource_name` to oci-build flavor and Docker build pipeline for apiary-mobile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/generated

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /generated
+generated.yml

--- a/README.md
+++ b/README.md
@@ -2,3 +2,15 @@
 [![GitHub license](https://img.shields.io/github/license/RoboJackets/concourse-pipeline-library)](https://github.com/RoboJackets/concourse-pipeline-library/blob/main/LICENSE) [![CI](https://concourse.robojackets.org/api/v1/teams/information-technology/pipelines/pipeline-library/jobs/build-main/badge)](https://concourse.robojackets.org/teams/information-technology/pipelines/pipeline-library)
 
 Collection of reusable tasks and pipelines for Concourse
+
+## Usage
+
+For testing, you can generate the pipeline files locally.
+
+Install dependencies:
+- Python >= 3.6
+- [`jq`](https://stedolan.github.io/jq/download/)
+- [`yq`](https://pypi.org/project/yq/) (be sure to install the Python version)
+- [`spruce`](https://github.com/geofffranks/spruce)
+
+Generate the pipelines by running `tools/generate.sh` **from the root of this repository**

--- a/flavors/oci-build.yml
+++ b/flavors/oci-build.yml
@@ -2,6 +2,7 @@
 base_image:
 
   repository: (( param "What base image is used?" ))
+  resource_name: (( param "What should we call the resource for the base image?"))
   tag: (( param "What tag is used?" ))
   icon: (( param "Which icon should be displayed?" ))
 
@@ -12,7 +13,7 @@ destination:
 
 resources:
 
-- name: (( grab base_image.repository ))
+- name: (( grab base_image.resource_name ))
   type: registry-image
   public: true
   icon: (( grab base_image.icon ))
@@ -58,7 +59,7 @@ resources:
 tasks:
 
   get_base_image:
-    get: (( grab base_image.repository ))
+    get: (( grab base_image.resource_name ))
     trigger: true
     params:
       format: oci
@@ -69,7 +70,7 @@ tasks:
     input_mapping:
       source: (( grab repository.name ))
     params:
-      IMAGE_ARG_base_image: (( concat base_image.repository "/image.tar" ))
+      IMAGE_ARG_base_image: (( concat base_image.resource_name "/image.tar" ))
     privileged: true
     timeout: 30m
     on_abort:

--- a/pipelines/information-technology/apiary-mobile-docker-build.yml
+++ b/pipelines/information-technology/apiary-mobile-docker-build.yml
@@ -18,7 +18,6 @@ resource_types:
     resources:
       apiary-mobile: (( grab webhook_configuration ))
 
-
 resources:
 
 - (( merge on name ))
@@ -32,12 +31,12 @@ resources:
   source:
     paths:
     - ci/dockerfiles/Dockerfile
-  
+
 tasks:
 
   get_base_image:
     tags:
-      - large
+    - large
     timeout: 5m
 
   build_image:
@@ -45,10 +44,9 @@ tasks:
       CONTEXT: source
       DOCKERFILE: source/ci/dockerfiles/Dockerfile
     tags:
-      - large
+    - large
 
   put_image:
     tags:
-      - large
+    - large
     timeout: 10m
-    

--- a/pipelines/information-technology/apiary-mobile-docker-build.yml
+++ b/pipelines/information-technology/apiary-mobile-docker-build.yml
@@ -8,6 +8,7 @@ repository:
 
 base_image:
   repository: mingc/android-build-box
+  resource_name: android-build-box
   tag: 1.24.0
   icon: docker
 
@@ -15,7 +16,8 @@ resource_types:
 - name: github-webhook
   defaults:
     resources:
-      mjackets-api: (( grab webhook_configuration ))
+      apiary-mobile: (( grab webhook_configuration ))
+
 
 resources:
 
@@ -30,9 +32,23 @@ resources:
   source:
     paths:
     - ci/dockerfiles/Dockerfile
-
+  
 tasks:
+
+  get_base_image:
+    tags:
+      - large
+    timeout: 5m
 
   build_image:
     params:
-      CONTEXT: source/ci/mjackets-build
+      CONTEXT: source
+      DOCKERFILE: source/ci/dockerfiles/Dockerfile
+    tags:
+      - large
+
+  put_image:
+    tags:
+      - large
+    timeout: 10m
+    

--- a/pipelines/information-technology/apiary-mobile-docker-build.yml
+++ b/pipelines/information-technology/apiary-mobile-docker-build.yml
@@ -8,7 +8,7 @@ repository:
 
 base_image:
   repository: mingc/android-build-box
-  resource_name: android-build-box
+  resource_name: android
   tag: 1.24.0
   icon: docker
 

--- a/pipelines/information-technology/fly.yml
+++ b/pipelines/information-technology/fly.yml
@@ -8,7 +8,7 @@ repository:
   main_branch: main
 
 base_image:
-  
+
   repository: alpine
   resource_name: alpine
   tag: latest

--- a/pipelines/information-technology/fly.yml
+++ b/pipelines/information-technology/fly.yml
@@ -8,8 +8,9 @@ repository:
   main_branch: main
 
 base_image:
-
+  
   repository: alpine
+  resource_name: alpine
   tag: latest
   icon: image-filter-hdr
 

--- a/pipelines/information-technology/github-approval.yml
+++ b/pipelines/information-technology/github-approval.yml
@@ -8,6 +8,7 @@ repository:
 
 base_image:
   repository: python
+  resource_name: python
   tag: 3.8-alpine
   icon: language-python
 

--- a/pipelines/information-technology/github-check.yml
+++ b/pipelines/information-technology/github-check.yml
@@ -8,6 +8,7 @@ repository:
 
 base_image:
   repository: python
+  resource_name: python
   tag: 3.8-alpine
   icon: language-python
 

--- a/pipelines/information-technology/github-deployment.yml
+++ b/pipelines/information-technology/github-deployment.yml
@@ -8,6 +8,7 @@ repository:
 
 base_image:
   repository: python
+  resource_name: python
   tag: 3.8-alpine
   icon: language-python
 

--- a/pipelines/information-technology/github-merge.yml
+++ b/pipelines/information-technology/github-merge.yml
@@ -8,6 +8,7 @@ repository:
 
 base_image:
   repository: python
+  resource_name: python
   tag: 3.8-alpine
   icon: language-python
 

--- a/pipelines/information-technology/github-webhook.yml
+++ b/pipelines/information-technology/github-webhook.yml
@@ -8,6 +8,7 @@ repository:
 
 base_image:
   repository: python
+  resource_name: python
   tag: 3.8-alpine
   icon: language-python
 

--- a/pipelines/information-technology/php-build.yml
+++ b/pipelines/information-technology/php-build.yml
@@ -8,6 +8,7 @@ repository:
 
 base_image:
   repository: ubuntu
+  resource_name: ubuntu
   tag: latest
   icon: ubuntu
 

--- a/pipelines/information-technology/python-build.yml
+++ b/pipelines/information-technology/python-build.yml
@@ -10,6 +10,7 @@ repository:
 base_image:
 
   repository: ubuntu
+  resource_name: python
   tag: latest
   icon: ubuntu
 

--- a/pipelines/mjackets/docker-build.yml
+++ b/pipelines/mjackets/docker-build.yml
@@ -8,6 +8,7 @@ repository:
 
 base_image:
   repository: ubuntu
+  resource_name: ubuntu
   tag: "20.04"
   icon: ubuntu
 

--- a/tasks/oci-build.yml
+++ b/tasks/oci-build.yml
@@ -12,7 +12,7 @@ params:
 
 inputs:
 - name: source
-- name: (( grab base_image.repository ))
+- name: (( grab base_image.resource_name ))
 
 outputs:
 - name: image

--- a/tools/generate.sh
+++ b/tools/generate.sh
@@ -14,7 +14,7 @@ generate_pipeline () {  if test -f "go-patch/$3.yml"
 }
 
 rm -f generated.yml
-mkdir generated
+mkdir -p generated
 
 for team in pipelines/*
 do

--- a/tools/generate.sh
+++ b/tools/generate.sh
@@ -14,6 +14,7 @@ generate_pipeline () {  if test -f "go-patch/$3.yml"
 }
 
 rm -f generated.yml
+mkdir generated
 
 for team in pipelines/*
 do


### PR DESCRIPTION
- Adds Docker image build pipeline for apiary-mobile's build image
- Added `resource_name` prop to oci-build flavor.  This can usually be the same as the repository name for the Docker image, but if there's a `/`, then the name can't also be used for Concourse tasks/resources, which is when specifying a resource name that's different from the repo name is useful
- Add .gitignore to ignore generated files
- Add instructions for use to README