### PR TITLE
Run Docker builds on large workers, skip asset compression

### DIFF
--- a/pipelines/information-technology/apiary.yml
+++ b/pipelines/information-technology/apiary.yml
@@ -282,6 +282,7 @@ jobs:
           params:
             BUILDKIT_SECRET_composer_auth: composer-auth/auth.json
             BUILDKIT_PROGRESS: plain
+            TARGET: backend-compressed
         tags:
         - large
 

--- a/pipelines/information-technology/apiary.yml
+++ b/pipelines/information-technology/apiary.yml
@@ -408,7 +408,7 @@ jobs:
         args:
         - -i
         - >-
-            /job/c\job "apiary-test" {
+            /job "apiary" {/c\job "apiary-test" {
         - apiary.nomad
 
   - put: deployment
@@ -496,7 +496,7 @@ jobs:
         args:
         - -i
         - >-
-            /job/c\job "apiary-google-play-review" {
+            /job "apiary" {/c\job "apiary-google-play-review" {
         - apiary.nomad
 
   - put: deployment
@@ -584,7 +584,7 @@ jobs:
         args:
         - -i
         - >-
-            /job/c\job "apiary-production" {
+            /job "apiary" {/c\job "apiary-production" {
         - apiary.nomad
 
   - put: deployment
@@ -809,7 +809,7 @@ jobs:
         args:
         - -i
         - >-
-            /job/c\job "apiary-test" {
+            /job "apiary" {/c\job "apiary-test" {
         - apiary.nomad
     input_mapping:
       apiary: pull-request

--- a/pipelines/information-technology/apiary.yml
+++ b/pipelines/information-technology/apiary.yml
@@ -282,6 +282,8 @@ jobs:
           params:
             BUILDKIT_SECRET_composer_auth: composer-auth/auth.json
             BUILDKIT_PROGRESS: plain
+        tags:
+        - large
 
       - (( grab tasks.put_build_check ))
 
@@ -290,7 +292,9 @@ jobs:
   - put: push-check
     inputs: []
 
-  - (( grab tasks.put_image ))
+  - inject: (( inject tasks.put_image ))
+    tags:
+    - large
 
   - put: webhooks
     inputs: []
@@ -421,6 +425,8 @@ jobs:
         - run
         - -var
         - image=registry.bcdc.robojackets.net/robojackets/apiary@((.:image_digest))
+        - -var
+        - precompressed_assets=true
         - -var-file
         - var-files/test.hcl
         - apiary.nomad
@@ -507,6 +513,8 @@ jobs:
         - run
         - -var
         - image=registry.bcdc.robojackets.net/robojackets/apiary@((.:image_digest))
+        - -var
+        - precompressed_assets=true
         - -var-file
         - var-files/google-play-review.hcl
         - apiary.nomad
@@ -593,6 +601,8 @@ jobs:
         - run
         - -var
         - image=registry.bcdc.robojackets.net/robojackets/apiary@((.:image_digest))
+        - -var
+        - precompressed_assets=true
         - -var-file
         - var-files/production.hcl
         - apiary.nomad
@@ -734,8 +744,11 @@ jobs:
           params:
             BUILDKIT_SECRET_composer_auth: composer-auth/auth.json
             BUILDKIT_PROGRESS: plain
+            TARGET: backend-uncompressed
         input_mapping:
           source: pull-request
+        tags:
+        - large
 
       - (( grab tasks.put_build_check ))
 
@@ -751,7 +764,9 @@ jobs:
   - put: push-check
     inputs: []
 
-  - (( grab tasks.put_image ))
+  - inject: (( inject tasks.put_image ))
+    tags:
+    - large
 
   - put: approve-pull-request
     inputs: []
@@ -819,6 +834,8 @@ jobs:
         - run
         - -var
         - image=registry.bcdc.robojackets.net/robojackets/apiary@((.:image_digest))
+        - -var
+        - precompressed_assets=false
         - -var-file
         - var-files/test.hcl
         - apiary.nomad


### PR DESCRIPTION
Closes https://github.com/RoboJackets/apiary/issues/2487